### PR TITLE
Add check for Object.isFrozen() in isPojo()

### DIFF
--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -8,6 +8,8 @@ export function isPojo(target) {
     &&
     typeof target === 'object'
     &&
+    !Object.isFrozen(target)
+    &&
     Object.prototype.toString.call(target) === '[object Object]'
     &&
     isFunction(Ctor)


### PR DESCRIPTION
This adds support for seamless-immutable.js which freezes property fields.  Without this change StateFunctions.js will attempt to delete frozen keys and throws an error.  This simple additional check for Object.isFrozen() enables alt.bootstrap({}) to work with seamless-immutable.
